### PR TITLE
Add bulk payment allocation endpoint

### DIFF
--- a/Controllers/InvoicesController.cs
+++ b/Controllers/InvoicesController.cs
@@ -425,6 +425,32 @@ namespace Invoqs.API.Controllers
         }
 
         /// <summary>
+        /// Record a payment across multiple invoices in a single transaction
+        /// </summary>
+        [HttpPost("bulk-payment")]
+        public async Task<ActionResult> RecordBulkPayment([FromBody] BulkPaymentDTO bulkPaymentDTO)
+        {
+            _logger.LogInformation("Recording bulk payment for {Count} invoices for user {UserId}",
+                bulkPaymentDTO.Allocations.Count, User.Identity?.Name);
+
+            try
+            {
+                await _invoiceService.RecordBulkPaymentAsync(bulkPaymentDTO);
+                return Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning("Bulk payment failed: {Error}", ex.Message);
+                return BadRequest(new { error = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error recording bulk payment for user {UserId}", User.Identity?.Name);
+                return StatusCode(500, new { error = "An error occurred while recording the bulk payment" });
+            }
+        }
+
+        /// <summary>
         /// Cancel invoice
         /// </summary>
         [HttpPost("{id:int}/cancel")]

--- a/DTOs/InvoiceDTO.cs
+++ b/DTOs/InvoiceDTO.cs
@@ -222,6 +222,27 @@ public class MarkInvoiceAsPaidDTO
 }
 
 /// <summary>
+/// A single invoice allocation within a bulk payment
+/// </summary>
+public class BulkPaymentAllocationDTO
+{
+    public int InvoiceId { get; set; }
+    public decimal Amount { get; set; }
+}
+
+/// <summary>
+/// Data for recording a payment across multiple invoices in one go
+/// </summary>
+public class BulkPaymentDTO
+{
+    public DateTime PaymentDate { get; set; } = DateTime.Today;
+    public string PaymentMethod { get; set; } = "Bank Transfer";
+    public string? PaymentReference { get; set; }
+    public string? Notes { get; set; }
+    public List<BulkPaymentAllocationDTO> Allocations { get; set; } = new();
+}
+
+/// <summary>
 /// Data for cancelling an invoice
 /// </summary>
 public class CancelInvoiceDTO

--- a/Interfaces/IInvoiceService.cs
+++ b/Interfaces/IInvoiceService.cs
@@ -15,6 +15,7 @@ public interface IInvoiceService
     Task<InvoiceDTO?> RecordPaymentAsync(int invoiceId, RecordPaymentDTO paymentDTO);
     Task<InvoiceDTO?> MarkInvoiceAsPaidAsync(int id, MarkInvoiceAsPaidDTO paymentDTO);
     Task<InvoiceDTO?> CancelInvoiceAsync(int id, CancelInvoiceDTO? cancelDTO = null);
+    Task<bool> RecordBulkPaymentAsync(BulkPaymentDTO bulkPaymentDTO);
     Task<decimal> GetTotalOutstandingAsync();
     // Task<InvoiceStatisticsDTO> GetInvoiceStatisticsAsync();
 }

--- a/Services/InvoiceService.cs
+++ b/Services/InvoiceService.cs
@@ -772,6 +772,83 @@ public class InvoiceService : IInvoiceService
         }
     }
 
+    public async Task<bool> RecordBulkPaymentAsync(BulkPaymentDTO bulkPaymentDTO)
+    {
+        var activeAllocations = bulkPaymentDTO.Allocations.Where(a => a.Amount > 0).ToList();
+        if (!activeAllocations.Any())
+            throw new InvalidOperationException("No allocations with a positive amount provided");
+
+        using var transaction = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            foreach (var allocation in activeAllocations)
+            {
+                var invoice = await _context.Invoices
+                    .Include(i => i.Payments)
+                    .FirstOrDefaultAsync(i => i.Id == allocation.InvoiceId);
+
+                if (invoice == null)
+                    throw new InvalidOperationException($"Invoice {allocation.InvoiceId} not found");
+
+                if (invoice.Status != InvoiceStatus.Sent &&
+                    invoice.Status != InvoiceStatus.Delivered &&
+                    invoice.Status != InvoiceStatus.Overdue &&
+                    invoice.Status != InvoiceStatus.PartiallyPaid)
+                    throw new InvalidOperationException(
+                        $"Invoice {invoice.InvoiceNumber} cannot receive payments in its current status");
+
+                var amountPaid = invoice.Payments?.Where(p => !p.IsDeleted).Sum(p => p.Amount) ?? 0;
+                var remainingAmount = invoice.Total - amountPaid;
+
+                if (allocation.Amount > remainingAmount + 0.01m)
+                    throw new InvalidOperationException(
+                        $"Payment amount for {invoice.InvoiceNumber} exceeds remaining balance of €{remainingAmount:N2}");
+
+                var payment = new InvoicePayment
+                {
+                    InvoiceId = allocation.InvoiceId,
+                    Amount = allocation.Amount,
+                    PaymentDate = bulkPaymentDTO.PaymentDate,
+                    PaymentMethod = bulkPaymentDTO.PaymentMethod,
+                    PaymentReference = bulkPaymentDTO.PaymentReference,
+                    Notes = bulkPaymentDTO.Notes,
+                    CreatedDate = DateTime.UtcNow
+                };
+
+                _context.InvoicePayments.Add(payment);
+
+                var newAmountPaid = amountPaid + allocation.Amount;
+                var newRemaining = invoice.Total - newAmountPaid;
+
+                if (newRemaining <= 0.01m)
+                {
+                    invoice.Status = InvoiceStatus.Paid;
+                    invoice.PaymentDate = bulkPaymentDTO.PaymentDate;
+                    invoice.PaymentMethod = bulkPaymentDTO.PaymentMethod;
+                    invoice.PaymentReference = bulkPaymentDTO.PaymentReference;
+                }
+                else
+                {
+                    invoice.Status = InvoiceStatus.PartiallyPaid;
+                }
+
+                invoice.UpdatedDate = DateTime.UtcNow;
+            }
+
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
+
+            _logger.LogInformation("Bulk payment recorded for {Count} invoices", activeAllocations.Count);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            await transaction.RollbackAsync();
+            _logger.LogError(ex, "Error recording bulk payment");
+            throw;
+        }
+    }
+
     public async Task<decimal> GetTotalOutstandingAsync()
     {
         try


### PR DESCRIPTION
Adds POST /api/invoices/bulk-payment to record a lump-sum payment across multiple invoices in a single transaction. Auto-handles full/partial status transitions per invoice.